### PR TITLE
Løftet versjonsnummeret for de aller fleste avhengighetene

### DIFF
--- a/src/main/kotlin/RecommendedVersions.kt
+++ b/src/main/kotlin/RecommendedVersions.kt
@@ -15,16 +15,19 @@ object Brukernotifikasjon {
 object DittNAV {
     object Common {
         private const val version = "2020.10.05-08.55-d4650785151c"
-        const val logging = "com.github.navikt.dittnav-common-lib:dittnav-common-logging:$version"
-        const val metrics = "com.github.navikt.dittnav-common-lib:dittnav-common-metrics:$version"
-        const val security = "com.github.navikt.dittnav-common-lib:dittnav-common-security:$version"
-        const val test = "com.github.navikt.dittnav-common-lib:dittnav-common-test:$version"
-        const val utils = "com.github.navikt.dittnav-common-lib:dittnav-common-utils:$version"
+        private const val groupId = "com.github.navikt.dittnav-common-lib"
+
+        const val logging = "$groupId:dittnav-common-logging:$version"
+        const val metrics = "$groupId:dittnav-common-metrics:$version"
+        const val security = "$groupId:dittnav-common-security:$version"
+        const val test = "$groupId:dittnav-common-test:$version"
+        const val utils = "$groupId:dittnav-common-utils:$version"
     }
 }
 
 object Flyway {
     const val version = "5.2.4"
+
     const val pluginId = "org.flywaydb.flyway"
     const val core = "org.flywaydb:flyway-core:$version"
 }
@@ -46,36 +49,45 @@ object Influxdb {
 
 object Jackson {
     private const val version = "2.9.9"
+
     const val dataTypeJsr310 = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$version"
     const val moduleKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin:$version"
 }
 
 object Junit {
     private const val version = "5.4.1"
-    const val api = "org.junit.jupiter:junit-jupiter-api:$version"
-    const val engine = "org.junit.jupiter:junit-jupiter-engine:$version"
-    const val params = "org.junit.jupiter:junit-jupiter-params:$version"
+    private const val groupId = "org.junit.jupiter"
+
+    const val api = "$groupId:junit-jupiter-api:$version"
+    const val engine = "$groupId:junit-jupiter-engine:$version"
+    const val params = "$groupId:junit-jupiter-params:$version"
 }
 
 object Jjwt {
     private const val version = "0.11.0"
-    const val api = "io.jsonwebtoken:jjwt-api:$version"
-    const val impl = "io.jsonwebtoken:jjwt-impl:$version"
-    const val jackson = "io.jsonwebtoken:jjwt-jackson:$version"
+    private const val groupId = "io.jsonwebtoken"
+
+    const val api = "$groupId:jjwt-api:$version"
+    const val impl = "$groupId:jjwt-impl:$version"
+    const val jackson = "$groupId:jjwt-jackson:$version"
 }
 
 object Kafka {
     object Apache {
         private const val version = "2.3.0"
-        const val clients = "org.apache.kafka:kafka-clients:$version"
-        const val kafka_2_12 = "org.apache.kafka:kafka_2.12:$version"
-        const val streams = "org.apache.kafka:kafka-streams:$version"
+        private const val groupId = "org.apache.kafka"
+
+        const val clients = "$groupId:kafka-clients:$version"
+        const val kafka_2_12 = "$groupId:kafka_2.12:$version"
+        const val streams = "$groupId:kafka-streams:$version"
     }
 
     object Confluent {
         private const val version = "5.3.0"
-        const val avroSerializer = "io.confluent:kafka-avro-serializer:$version"
-        const val schemaRegistry = "io.confluent:kafka-schema-registry:$version"
+        private const val groupId = "io.confluent"
+
+        const val avroSerializer = "$groupId:kafka-avro-serializer:$version"
+        const val schemaRegistry = "$groupId:kafka-schema-registry:$version"
     }
 }
 
@@ -89,12 +101,16 @@ object Kotlin {
 }
 
 object Kotlinx {
-    const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3"
-    const val htmlJvm = "org.jetbrains.kotlinx:kotlinx-html-jvm:0.6.12"
+    private const val groupId = "org.jetbrains.kotlinx"
+
+    const val coroutines = "$groupId:kotlinx-coroutines-core:1.3.3"
+    const val htmlJvm = "$groupId:kotlinx-html-jvm:0.6.12"
 }
 
 object Ktor {
     private const val version = "1.3.2"
+    private const val groupId = "io.ktor"
+
     const val auth = "io.ktor:ktor-auth:$version"
     const val authJwt = "io.ktor:ktor-auth-jwt:$version"
     const val htmlBuilder = "io.ktor:ktor-html-builder:$version"
@@ -138,11 +154,13 @@ object Postgresql {
 
 object Prometheus {
     private const val version = "0.8.1"
-    const val common = "io.prometheus:simpleclient_common:$version"
-    const val hotspot = "io.prometheus:simpleclient_hotspot:$version"
-    const val httpServer = "io.prometheus:simpleclient_httpserver:$version"
-    const val logback = "io.prometheus:simpleclient_logback:$version"
-    const val simpleClient = "io.prometheus:simpleclient:$version"
+    private const val groupId = "io.prometheus"
+
+    const val common = "$groupId:simpleclient_common:$version"
+    const val hotspot = "$groupId:simpleclient_hotspot:$version"
+    const val httpServer = "$groupId:simpleclient_httpserver:$version"
+    const val logback = "$groupId:simpleclient_logback:$version"
+    const val simpleClient = "$groupId:simpleclient:$version"
 }
 
 object Shadow {

--- a/src/main/kotlin/RecommendedVersions.kt
+++ b/src/main/kotlin/RecommendedVersions.kt
@@ -3,7 +3,7 @@
  */
 
 object Bouncycastle {
-    private const val version = "1.64"
+    private const val version = "1.66"
     const val bcprovJdk15on = "org.bouncycastle:bcprov-jdk15on:$version"
 }
 
@@ -26,8 +26,7 @@ object DittNAV {
 }
 
 object Flyway {
-    const val version = "5.2.4"
-
+    const val version = "6.5.7"
     const val pluginId = "org.flywaydb.flyway"
     const val core = "org.flywaydb:flyway-core:$version"
 }
@@ -38,19 +37,19 @@ object H2Database {
 }
 
 object Hikari {
-    private const val version = "3.2.0"
+    private const val version = "3.4.5"
     const val cp = "com.zaxxer:HikariCP:$version"
 }
 
 object Influxdb {
-    private const val version = "2.8"
+    private const val version = "2.20"
     const val java = "org.influxdb:influxdb-java:$version"
 }
 
 object Jackson {
-    private const val version = "2.9.9"
-
-    const val dataTypeJsr310 = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$version"
+    private const val version = "2.11.3"
+    private const val groupId = "com.fasterxml.jackson.datatype"
+    const val dataTypeJsr310 = "$groupId:jackson-datatype-jsr310:$version"
     const val moduleKotlin = "com.fasterxml.jackson.module:jackson-module-kotlin:$version"
 }
 
@@ -64,7 +63,7 @@ object Junit {
 }
 
 object Jjwt {
-    private const val version = "0.11.0"
+    private const val version = "0.11.2"
     private const val groupId = "io.jsonwebtoken"
 
     const val api = "$groupId:jjwt-api:$version"
@@ -74,7 +73,7 @@ object Jjwt {
 
 object Kafka {
     object Apache {
-        private const val version = "2.3.0"
+        private const val version = "2.5.1"
         private const val groupId = "org.apache.kafka"
 
         const val clients = "$groupId:kafka-clients:$version"
@@ -83,7 +82,7 @@ object Kafka {
     }
 
     object Confluent {
-        private const val version = "5.3.0"
+        private const val version = "5.5.0"
         private const val groupId = "io.confluent"
 
         const val avroSerializer = "$groupId:kafka-avro-serializer:$version"
@@ -97,18 +96,18 @@ object Kluent {
 }
 
 object Kotlin {
-    const val version = "1.3.70"
+    const val version = "1.4.10"
 }
 
 object Kotlinx {
     private const val groupId = "org.jetbrains.kotlinx"
 
-    const val coroutines = "$groupId:kotlinx-coroutines-core:1.3.3"
-    const val htmlJvm = "$groupId:kotlinx-html-jvm:0.6.12"
+    const val coroutines = "$groupId:kotlinx-coroutines-core:1.3.9"
+    const val htmlJvm = "$groupId:kotlinx-html-jvm:0.7.2"
 }
 
 object Ktor {
-    private const val version = "1.3.2"
+    private const val version = "1.4.1"
     private const val groupId = "io.ktor"
 
     const val auth = "io.ktor:ktor-auth:$version"
@@ -132,7 +131,7 @@ object Logback {
 }
 
 object Logstash {
-    private const val version = "5.2"
+    private const val version = "6.4"
     const val logbackEncoder = "net.logstash.logback:logstash-logback-encoder:$version"
 }
 
@@ -142,18 +141,18 @@ object Mockk {
 }
 
 object NAV {
-    const val vaultJdbc = "no.nav:vault-jdbc:1.3.1"
+    const val vaultJdbc = "no.nav:vault-jdbc:1.3.7"
     const val kafkaEmbedded = "no.nav:kafka-embedded-env:2.5.0"
     const val tokenValidatorKtor = "no.nav.security:token-validation-ktor:1.3.0"
 }
 
 object Postgresql {
-    private const val version = "42.2.5"
+    private const val version = "42.2.16"
     const val postgresql = "org.postgresql:postgresql:$version"
 }
 
 object Prometheus {
-    private const val version = "0.8.1"
+    private const val version = "0.9.0"
     private const val groupId = "io.prometheus"
 
     const val common = "$groupId:simpleclient_common:$version"
@@ -169,6 +168,6 @@ object Shadow {
 }
 
 object Auth0 {
-    private const val version = "3.10.3"
+    private const val version = "3.11.0"
     const val javajwt = "com.auth0:java-jwt:$version"
 }


### PR DESCRIPTION
Løftet alle versjoner unntatt Kluent og Mockk, fordi de hadde mange api-endringer.

Kafka er løftet til samme versjon som `kafka-embedded-env` bruker.