### PR TITLE
Legger til nye miljøvariabler

### DIFF
--- a/src/main/kotlin/DockerComposeDefaults.kt
+++ b/src/main/kotlin/DockerComposeDefaults.kt
@@ -8,6 +8,8 @@ object DockerComposeDefaults {
         "OIDC_ISSUER" to "http://localhost:9000",
         "OIDC_DISCOVERY_URL" to "http://localhost:9000/.well-known/openid-configuration",
         "OIDC_ACCEPTED_AUDIENCE" to "stubOidcClient",
+        "LOGINSERVICE_IDPORTEN_DISCOVERY_URL" to "http://localhost:9000/.well-known/openid-configuration",
+        "LOGINSERVICE_IDPORTEN_AUDIENCE" to "stubOidcClient",
         "OIDC_CLAIM_CONTAINING_THE_IDENTITY" to "pid",
 
         "KAFKA_BOOTSTRAP_SERVERS" to "localhost:29092",


### PR DESCRIPTION
Legger til nye miljøvariabler som appene våre forventer ved lokal kjøring med ./gradlew runServer og docker-compose.

Foreløpig lar vi de gamle være, inntil alle apper ikke lengre er avhengig av de.