### PR TITLE
Legger til avhengighet for Awaitility.

### DIFF
--- a/src/main/kotlin/RecommendedVersions.kt
+++ b/src/main/kotlin/RecommendedVersions.kt
@@ -189,3 +189,10 @@ object TestContainers {
     const val junitJupiter = "$groupId:junit-jupiter:$version"
     const val testContainers = "$groupId:testcontainers:$version"
 }
+
+object Awaitility {
+    private const val version = "4.0.3"
+    private const val groupId = "org.awaitility"
+
+    const val awaitilityKotlin = "$groupId:awaitility-kotlin:$version"
+}


### PR DESCRIPTION
Dette biblioteket brukes for å slippe det faste ventesteget i e2e-testene.